### PR TITLE
Prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.3.0] - 2019-04-01
+
 ### Changed
 
 - Remove core code; use libcove instead.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='libcoveocds',
-    version='0.2.2',
+    version='0.3.0',
     author='Open Data Services',
     author_email='code@opendataservices.coop',
     url='https://github.com/open-contracting/lib-cove-ocds',


### PR DESCRIPTION
Diff from last release: https://github.com/open-contracting/lib-cove-ocds/compare/v0.2.2...release-0.3.0