### PR TITLE
Fix OCID prefix regular expression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- get_bad_ocds_prefixes no longer tests for hyphens after OCID prefixes, and no longer allows uppercase letters in OCID prefixes.
+
 ## [0.7.0] - 2019-06-26
 
 ### Changed

--- a/libcoveocds/lib/common_checks.py
+++ b/libcoveocds/lib/common_checks.py
@@ -382,7 +382,7 @@ def get_records_aggregates(json_data):
 
 def get_bad_ocds_prefixes(json_data):
     '''Yield tuples with ('ocid', 'path/to/ocid') for ocids with malformed prefixes'''
-    prefix_regex = re.compile(r'^ocds-[a-zA-Z0-9]{6}-')
+    prefix_regex = re.compile(r'^ocds-[a-z0-9]{6}.?')
     releases = json_data.get('releases', [])
     records = json_data.get('records', [])
     bad_prefixes = []

--- a/libcoveocds/lib/common_checks.py
+++ b/libcoveocds/lib/common_checks.py
@@ -382,7 +382,7 @@ def get_records_aggregates(json_data):
 
 def get_bad_ocds_prefixes(json_data):
     '''Yield tuples with ('ocid', 'path/to/ocid') for ocids with malformed prefixes'''
-    prefix_regex = re.compile(r'^ocds-[a-z0-9]{6}.?')
+    prefix_regex = re.compile(r'^ocds-[a-z0-9]{6}')
     releases = json_data.get('releases', [])
     records = json_data.get('records', [])
     bad_prefixes = []


### PR DESCRIPTION
- The trailing hyphen is not part of the OCID prefix.
- The OCID prefix is case-sensitive (and A-Z are not possible characters).
- The OCID prefix must prefix at least one character.