### PR TITLE
Cache requests in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] 
+
+### Changed
+
+- Cache all requests in the tests https://github.com/OpenDataServices/lib-cove/pull/59
+
 ## [0.8.0] - 2020-08-26
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     long_description=long_description,
     install_requires=[
-        'libcove>=0.18.0',
+        'libcove>=0.19.0',
         'bleach',
         'cached-property',
         'CommonMark',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,12 @@ import tempfile
 
 import pytest
 
+import libcoveocds.config
 from libcoveocds.api import APIException, ocds_json_output
+
+# Cache for faster tests.
+config = libcoveocds.config.LibCoveOCDSConfig()
+config.config['cache_all_requests'] = True
 
 
 def test_basic_1():
@@ -14,7 +19,8 @@ def test_basic_1():
         os.path.realpath(__file__)), 'fixtures', 'api', 'basic_1.json'
     )
 
-    results = ocds_json_output(cove_temp_folder, json_filename, schema_version='', convert=False)
+    results = ocds_json_output(cove_temp_folder, json_filename, schema_version='', convert=False,
+                               lib_cove_ocds_config=config)
 
     assert results['version_used'] == '1.1'
 

--- a/tests/test_common_checks.py
+++ b/tests/test_common_checks.py
@@ -6,13 +6,18 @@ import tempfile
 import pytest
 
 import libcoveocds.common_checks
+import libcoveocds.config
 import libcoveocds.schema
+
+# Cache for faster tests.
+config = libcoveocds.config.LibCoveOCDSConfig()
+config.config['cache_all_requests'] = True
 
 
 def test_basic_1():
 
     cove_temp_folder = tempfile.mkdtemp(prefix='libcoveocds-tests-', dir=tempfile.gettempdir())
-    schema = libcoveocds.schema.SchemaOCDS()
+    schema = libcoveocds.schema.SchemaOCDS(lib_cove_ocds_config=config)
     json_filename = os.path.join(os.path.dirname(
         os.path.realpath(__file__)), 'fixtures', 'common_checks', 'basic_1.json'
     )
@@ -41,7 +46,7 @@ def test_basic_1():
 def test_dupe_ids_1():
 
     cove_temp_folder = tempfile.mkdtemp(prefix='libcoveocds-tests-', dir=tempfile.gettempdir())
-    schema = libcoveocds.schema.SchemaOCDS()
+    schema = libcoveocds.schema.SchemaOCDS(lib_cove_ocds_config=config)
     json_filename = os.path.join(os.path.dirname(
         os.path.realpath(__file__)), 'fixtures', 'common_checks', 'dupe_ids_1.json'
     )
@@ -524,9 +529,9 @@ def test_validation_release_or_record_package(
 
     cove_temp_folder = tempfile.mkdtemp(prefix='libcoveocds-tests-', dir=tempfile.gettempdir())
     if package_schema_filename == 'record-package-schema.json':
-        schema = libcoveocds.schema.SchemaOCDS(record_pkg=True)
+        schema = libcoveocds.schema.SchemaOCDS(lib_cove_ocds_config=config, record_pkg=True)
     else:
-        schema = libcoveocds.schema.SchemaOCDS(record_pkg=False)
+        schema = libcoveocds.schema.SchemaOCDS(lib_cove_ocds_config=config, record_pkg=False)
     context = {
         'file_type': 'json',
     }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,6 +5,10 @@ import pytest
 import libcoveocds.config
 import libcoveocds.schema
 
+# Cache for faster tests.
+config = libcoveocds.config.LibCoveOCDSConfig()
+config.config['cache_all_requests'] = True
+
 DEFAULT_OCDS_VERSION = libcoveocds.config.LIB_COVE_OCDS_CONFIG_DEFAULT['schema_version']
 METRICS_EXT = 'https://raw.githubusercontent.com/open-contracting/ocds_metrics_extension/master/extension.json'
 CODELIST_EXT = 'https://raw.githubusercontent.com/INAImexico/ocds_extendedProcurementCategory_extension/0ed54770c85500cf21f46e88fb06a30a5a2132b1/extension.json' # noqa
@@ -101,7 +105,7 @@ def test_schema_ocds_constructor(select_version, release_data, version, invalid_
      {UNKNOWN_URL_EXT: 'fetching failed'}, True, True),
 ])
 def test_schema_ocds_extensions(release_data, extensions, invalid_extension, extended, extends_schema):
-    schema = libcoveocds.schema.SchemaOCDS(release_data=release_data)
+    schema = libcoveocds.schema.SchemaOCDS(release_data=release_data, lib_cove_ocds_config=config)
     assert schema.extensions == extensions
     assert not schema.extended
 


### PR DESCRIPTION
Paired with https://github.com/OpenDataServices/lib-cove/pull/59, cuts down test time from 40s to 6s.

The call graph shows that about 50% of the time (during tests) is spent in `get_request` (much better than before), all of which goes to `cached_get_request`.