### PR TITLE
common_checks: Modify oneOf validator to return more information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.0] - 2021-02-25
+
+## Changed
+
+- `common_checks_ocds` returns more fields on each error dictionary, so that we can [replace the message with a translation in cove-ocds](https://github.com/open-contracting/cove-ocds/pull/149)
+
 ### Fixed
 
 - libcoveocds commandline fails for record packages https://github.com/open-contracting/lib-cove-ocds/issues/39

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Changed
 
 - `common_checks_ocds` returns more fields on each error dictionary, so that we can [replace the message with a translation in cove-ocds](https://github.com/open-contracting/cove-ocds/pull/149)
+- Update the default config to use branch urls instead of tag urls for the schema. This means patch fixes will automatically be pulled in.
 
 ### Fixed
 

--- a/libcoveocds/config.py
+++ b/libcoveocds/config.py
@@ -10,8 +10,8 @@ LIB_COVE_OCDS_CONFIG_DEFAULT = {
     "schema_host": None,
     "schema_version_choices": OrderedDict(
         (  # {version: (display, url)}
-            ("1.0", ("1.0", "https://standard.open-contracting.org/schema/1__0__3/")),
-            ("1.1", ("1.1", "https://standard.open-contracting.org/schema/1__1__5/")),
+            ("1.0", ("1.0", "https://standard.open-contracting.org/1.0/en/")),
+            ("1.1", ("1.1", "https://standard.open-contracting.org/1.1/en/")),
         )
     ),
     "schema_codelists": OrderedDict(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst") as f:
 
 setup(
     name="libcoveocds",
-    version="0.9.1",
+    version="0.10.0",
     author="Open Data Services",
     author_email="data@open-contracting.org",
     url="https://github.com/open-contracting/lib-cove-ocds",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     long_description=long_description,
     install_requires=[
-        "libcove>=0.19.0",
+        "libcove>=0.22.0",
         "bleach",
         "cached-property",
         "CommonMark",

--- a/tests/test_common_checks.py
+++ b/tests/test_common_checks.py
@@ -221,7 +221,7 @@ def test_dupe_ids_1():
                     "null_clause": "",
                     "error_id": None,
                     "values": [{"path": "records/0/releases"}],
-                    "instance": "[]",
+                    "instance": [],
                 },
             ],
         ),
@@ -356,7 +356,7 @@ def test_dupe_ids_1():
                     "null_clause": "",
                     "error_id": None,
                     "values": [{"path": "records/0/releases"}],
-                    "instance": "[]",
+                    "instance": [],
                 },
             ],
         ),
@@ -558,4 +558,12 @@ def test_validation_release_or_record_package(record_pkg, filename, validation_e
             del validation_error_json["schema_title"]
         validation_error_jsons.append(validation_error_json)
 
-    assert validation_error_jsons == validation_error_jsons_expected
+    def strip_nones(list_of_dicts):
+        out = []
+        for a_dict in list_of_dicts:
+            out.append(
+                {key: value for key, value in a_dict.items() if value is not None}
+            )
+        return out
+
+    assert strip_nones(validation_error_jsons) == strip_nones(validation_error_jsons_expected)

--- a/tests/test_common_checks.py
+++ b/tests/test_common_checks.py
@@ -561,9 +561,7 @@ def test_validation_release_or_record_package(record_pkg, filename, validation_e
     def strip_nones(list_of_dicts):
         out = []
         for a_dict in list_of_dicts:
-            out.append(
-                {key: value for key, value in a_dict.items() if value is not None}
-            )
+            out.append({key: value for key, value in a_dict.items() if value is not None})
         return out
 
     assert strip_nones(validation_error_jsons) == strip_nones(validation_error_jsons_expected)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,8 +29,8 @@ def test_basic_1(record_pkg):
         assert schema.schema_name == "release-schema.json"
         assert schema.pkg_schema_name == "release-package-schema.json"
     assert schema.default_version == "1.1"
-    assert schema.default_schema_host == "https://standard.open-contracting.org/schema/1__1__5/"
-    assert schema.schema_host == "https://standard.open-contracting.org/schema/1__1__5/"
+    assert schema.default_schema_host == "https://standard.open-contracting.org/1.1/en/"
+    assert schema.schema_host == "https://standard.open-contracting.org/1.1/en/"
     assert not schema.config.config["cache_all_requests"]
 
 
@@ -59,8 +59,8 @@ def test_pass_config_1(record_pkg):
         assert schema.schema_name == "release-schema.json"
         assert schema.pkg_schema_name == "release-package-schema.json"
     assert schema.default_version == "1.0"
-    assert schema.default_schema_host == "https://standard.open-contracting.org/schema/1__0__3/"
-    assert schema.schema_host == "https://standard.open-contracting.org/schema/1__0__3/"
+    assert schema.default_schema_host == "https://standard.open-contracting.org/1.0/en/"
+    assert schema.schema_host == "https://standard.open-contracting.org/1.0/en/"
     assert not schema.config.config["cache_all_requests"]
 
 


### PR DESCRIPTION
Modify oneOf validator to return more information on each ValidationError, so that we can replace the message with a translation in cove_ocds.

https://github.com/open-contracting/cove-ocds/issues/144